### PR TITLE
Fixed incorrect alignment calculation.

### DIFF
--- a/Raids/RaidConfig.cs
+++ b/Raids/RaidConfig.cs
@@ -253,7 +253,7 @@ namespace DiscordBot.Raids
             var baseSize = sizeof(ulong) + sizeof(float) * this.GetRoles().Count;
 
             //Add padding so that the total size is some multiple of sizeof(ulong)
-            return (baseSize + sizeof(ulong)) & ~(sizeof(ulong) - 1);
+            return (baseSize + sizeof(ulong) - 1) & ~(sizeof(ulong) - 1);
         }
 
         public int GetOutputBlockSizeInBytes()


### PR DESCRIPTION
When already aligned, it would increase the size by the alignment value. This fixes that mistake.